### PR TITLE
feat: Issue #10 投稿一覧表示機能の実装（TanStack Query導入）

### DIFF
--- a/__tests__/app/page.test.tsx
+++ b/__tests__/app/page.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { AuthenticatedLanding } from "@/components/landing/AuthenticatedLanding";
 import { UnauthenticatedLanding } from "@/components/landing/UnauthenticatedLanding";
@@ -10,7 +11,37 @@ jest.mock("next/navigation", () => ({
   }),
 }));
 
+jest.mock("@/lib/postRepository", () => ({
+  postRepository: {
+    findMany: jest.fn().mockResolvedValue([]),
+  },
+}));
+
 describe("Home page components", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const renderWithQueryClient = (component: React.ReactElement) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        {component}
+      </QueryClientProvider>,
+    );
+  };
+
   test("UnauthenticatedLandingが正しく表示される", () => {
     render(<UnauthenticatedLanding />);
 
@@ -30,7 +61,7 @@ describe("Home page components", () => {
       name: "スタブユーザー",
     };
 
-    render(<AuthenticatedLanding session={mockSession} />);
+    renderWithQueryClient(<AuthenticatedLanding session={mockSession} />);
 
     // ログイン状態のヘッダーが表示される（ログインボタンは存在しない）
     expect(

--- a/__tests__/components/timeline/PostList.test.tsx
+++ b/__tests__/components/timeline/PostList.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { PostList } from "@/components/timeline/PostList";
+import type { PostDTO } from "@/lib/postRepository";
+
+// postRepositoryをモック
+jest.mock("@/lib/postRepository", () => ({
+  postRepository: {
+    findMany: jest.fn(),
+  },
+}));
+
+const mockPostRepository = require("@/lib/postRepository").postRepository as {
+  findMany: jest.MockedFunction<
+    typeof import("@/lib/postRepository").postRepository.findMany
+  >;
+};
+
+describe("PostList", () => {
+  let queryClient: QueryClient;
+  const TEST_AUTHOR_ID = "test-author";
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  const renderWithQueryClient = (component: React.ReactElement) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        {component}
+      </QueryClientProvider>,
+    );
+  };
+
+  it("ローディング中はスピナー表示・投稿非表示", async () => {
+    mockPostRepository.findMany.mockImplementation(
+      () =>
+        new Promise<PostDTO[]>((resolve) => {
+          // 意図的に遅延させてローディング状態を確認
+          setTimeout(() => resolve([]), 100);
+        }),
+    );
+
+    renderWithQueryClient(<PostList authorId={TEST_AUTHOR_ID} />);
+
+    // ローディング中はスピナーが表示される
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+
+    // 投稿はまだ表示されない
+    expect(screen.queryByTestId("post-item")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockPostRepository.findMany).toHaveBeenCalled();
+    });
+  });
+
+  it("取得成功時に10件を描画し、postRepository.findManyが正しい引数で呼ばれる", async () => {
+    const mockPosts: PostDTO[] = Array.from({ length: 10 }, (_, i) => ({
+      postId: `post-${i}`,
+      authorId: "test-user",
+      contentJSON: JSON.stringify({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: `投稿${i}` }],
+          },
+        ],
+      }),
+      status: "active",
+      mode: i % 2 === 0 ? "memo" : "todo",
+      createdAt: new Date(2025, 0, 1 + i),
+      updatedAt: new Date(2025, 0, 1 + i),
+      deletedAt: null,
+    }));
+
+    mockPostRepository.findMany.mockResolvedValue(mockPosts);
+
+    renderWithQueryClient(<PostList authorId={TEST_AUTHOR_ID} />);
+
+    await waitFor(() => {
+      expect(mockPostRepository.findMany).toHaveBeenCalledWith({
+        authorId: TEST_AUTHOR_ID,
+        limit: 10,
+        sortBy: "updatedAt",
+        sortOrder: "desc",
+      });
+    });
+
+    // 10件の投稿が表示されるまで待つ
+    await waitFor(() => {
+      const postItems = screen.getAllByTestId("post-item");
+      expect(postItems).toHaveLength(10);
+    });
+
+    // スピナーは非表示になる（フェードアウトを考慮して少し待つ）
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByRole("status", { name: "Loading" }),
+        ).not.toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("エラー時にエラーメッセージを表示し、再試行ボタンがrenderされる", async () => {
+    mockPostRepository.findMany.mockRejectedValue(
+      new Error("投稿を読み込めませんでした"),
+    );
+
+    renderWithQueryClient(<PostList authorId={TEST_AUTHOR_ID} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/投稿を読み込めませんでした/i),
+      ).toBeInTheDocument();
+    });
+
+    // 再試行ボタンが表示される
+    const retryButton = screen.getByRole("button", { name: /再試行/i });
+    expect(retryButton).toBeInTheDocument();
+
+    // 再試行ボタンをクリックすると再取得される
+    retryButton.click();
+
+    await waitFor(() => {
+      expect(mockPostRepository.findMany).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { QueryProvider } from "@/components/providers/query-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
@@ -30,8 +31,10 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-50 text-slate-900`}
       >
         <ThemeProvider>
-          {children}
-          <Toaster position="top-center" />
+          <QueryProvider>
+            {children}
+            <Toaster position="top-center" />
+          </QueryProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/landing/AuthenticatedLanding.tsx
+++ b/components/landing/AuthenticatedLanding.tsx
@@ -1,4 +1,5 @@
 import { AuthenticatedHeader } from "@/components/layout/AuthenticatedHeader";
+import { PostList } from "@/components/timeline/PostList";
 
 interface AuthenticatedLandingProps {
   session: {
@@ -13,9 +14,8 @@ export function AuthenticatedLanding({ session }: AuthenticatedLandingProps) {
     <div className="flex min-h-screen flex-col">
       <AuthenticatedHeader session={session} />
       <div className="flex-1">
-        {/* 後続のメイン領域（エディタ・一覧）は別タスクで実装 */}
-        <main className="container mx-auto px-4 py-8">
-          <p>ログイン中（画面B）</p>
+        <main>
+          <PostList authorId={session.userId} />
         </main>
       </div>
     </div>

--- a/components/providers/query-provider.tsx
+++ b/components/providers/query-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 30, // 30秒
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === "development" && (
+        <ReactQueryDevtools initialIsOpen={false} />
+      )}
+    </QueryClientProvider>
+  );
+}

--- a/components/timeline/PostItem.tsx
+++ b/components/timeline/PostItem.tsx
@@ -1,0 +1,67 @@
+import type { PostDTO } from "@/lib/postRepository";
+
+interface PostItemProps {
+  post: PostDTO;
+}
+
+/**
+ * PostItem
+ * 個別投稿の表示コンポーネント
+ */
+export function PostItem({ post }: PostItemProps) {
+  // tiptap JSONからテキストを抽出（暫定実装）
+  let textContent = "";
+  try {
+    const content = JSON.parse(post.contentJSON);
+    if (
+      content?.content?.[0]?.content?.[0]?.text &&
+      typeof content.content[0].content[0].text === "string"
+    ) {
+      textContent = content.content[0].content[0].text;
+    }
+  } catch {
+    // JSONパースエラー時は空文字
+    textContent = "";
+  }
+
+  // モード表示用のラベル
+  const modeLabel =
+    post.mode === "memo" ? "メモ" : post.mode === "todo" ? "ToDo" : "日記";
+
+  // 日時フォーマット（暫定: Intl.DateTimeFormat使用）
+  const formatDate = (date: Date) => {
+    return new Intl.DateTimeFormat("ja-JP", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  };
+
+  return (
+    <article
+      data-testid="post-item"
+      className="border-b border-slate-200 py-4 px-4 hover:bg-slate-50 transition-colors"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-xs font-medium text-slate-600 bg-slate-100 px-2 py-1 rounded">
+              {modeLabel}
+            </span>
+            <time
+              dateTime={post.updatedAt.toISOString()}
+              className="text-xs text-slate-500"
+            >
+              {formatDate(post.updatedAt)}
+            </time>
+          </div>
+          <p className="text-sm text-slate-900 whitespace-pre-wrap break-words">
+            {textContent || "(内容なし)"}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/components/timeline/PostList.tsx
+++ b/components/timeline/PostList.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { SpinnerWithFade } from "@/components/ui/spinner-with-fade";
+import { postRepository } from "@/lib/postRepository";
+import { PostItem } from "./PostItem";
+
+interface PostListProps {
+  authorId: string;
+}
+
+/**
+ * PostList
+ * 投稿一覧を表示するコンポーネント
+ * TanStack Queryでデータ取得・キャッシュ管理を行う
+ */
+export function PostList({ authorId }: PostListProps) {
+  const queryClient = useQueryClient();
+
+  const {
+    data: posts,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["posts", { authorId, mode: "all" }],
+    queryFn: async () => {
+      return await postRepository.findMany({
+        authorId,
+        limit: 10,
+        sortBy: "updatedAt",
+        sortOrder: "desc",
+      });
+    },
+  });
+
+  const handleRetry = () => {
+    queryClient.invalidateQueries({
+      queryKey: ["posts", { authorId, mode: "all" }],
+    });
+  };
+
+  if (isError) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center">
+          <p className="text-sm text-red-600 mb-4">
+            投稿を読み込めませんでした
+          </p>
+          <Button onClick={handleRetry} variant="outline" size="sm">
+            再試行
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-4">
+        <SpinnerWithFade isLoading={isLoading} />
+      </div>
+
+      {posts && posts.length > 0 && (
+        <div className="space-y-0">
+          {posts.map((post) => (
+            <PostItem key={post.postId} post={post} />
+          ))}
+        </div>
+      )}
+
+      {posts && posts.length === 0 && !isLoading && (
+        <div className="text-center py-8 text-slate-500 text-sm">
+          投稿がありません
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-query": "^5.90.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.561.0",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
     "@tailwindcss/postcss": "^4",
+    "@tanstack/react-query-devtools": "^5.91.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.1.0)
+      '@tanstack/react-query':
+        specifier: ^5.90.15
+        version: 5.90.15(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -57,6 +60,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
+      '@tanstack/react-query-devtools':
+        specifier: ^5.91.2
+        version: 5.91.2(@tanstack/react-query@5.90.15(react@19.1.0))(react@19.1.0)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1073,6 +1079,23 @@ packages:
 
   '@tailwindcss/postcss@4.1.17':
     resolution: {integrity: sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw==}
+
+  '@tanstack/query-core@5.90.15':
+    resolution: {integrity: sha512-mInIZNUZftbERE+/Hbtswfse49uUQwch46p+27gP9DWJL927UjnaWEF2t3RMOqBcXbfMdcNkPe06VyUIAZTV1g==}
+
+  '@tanstack/query-devtools@5.92.0':
+    resolution: {integrity: sha512-N8D27KH1vEpVacvZgJL27xC6yPFUy0Zkezn5gnB3L3gRCxlDeSuiya7fKge8Y91uMTnC8aSxBQhcK6ocY7alpQ==}
+
+  '@tanstack/react-query-devtools@5.91.2':
+    resolution: {integrity: sha512-ZJ1503ay5fFeEYFUdo7LMNFzZryi6B0Cacrgr2h1JRkvikK1khgIq6Nq2EcblqEdIlgB/r7XDW8f8DQ89RuUgg==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.90.14
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.90.15':
+    resolution: {integrity: sha512-uQvnDDcTOgJouNtAyrgRej+Azf0U5WDov3PXmHFUBc+t1INnAYhIlpZtCGNBLwCN41b43yO7dPNZu8xWkUFBwQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3496,6 +3519,21 @@ snapshots:
       '@tailwindcss/oxide': 4.1.17
       postcss: 8.5.6
       tailwindcss: 4.1.17
+
+  '@tanstack/query-core@5.90.15': {}
+
+  '@tanstack/query-devtools@5.92.0': {}
+
+  '@tanstack/react-query-devtools@5.91.2(@tanstack/react-query@5.90.15(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-devtools': 5.92.0
+      '@tanstack/react-query': 5.90.15(react@19.1.0)
+      react: 19.1.0
+
+  '@tanstack/react-query@5.90.15(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.90.15
+      react: 19.1.0
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
Issue #10 の投稿一覧表示機能を実装しました。

## 実装内容
- TanStack Query基盤を導入し、QueryProviderをapp/layout.tsxに統合
- PostListコンポーネントを実装（スタブpostRepositoryから初期10件を取得）
- PostItemコンポーネントを実装（モード・更新日・本文を表示）
- AuthenticatedLandingにPostListを統合し、ログイン後に投稿一覧を表示
- PostListのテストを追加（ローディング・成功・エラーケース）
- 既存テスト（page.test.tsx）にQueryClientProviderを追加して修正
